### PR TITLE
feat: added chatbot endpoint

### DIFF
--- a/app/Http/Controllers/ChatBotController.php
+++ b/app/Http/Controllers/ChatBotController.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+use Gemini;
+use Gemini\Data\Content;
+use Gemini\Enums\{ModelType, Role};
+
+class ChatBotController extends Controller
+{
+    protected $client;
+    protected $chat;
+    
+    public function __construct()
+    {
+        $this->client = Gemini::client(env('GEMINI_API_KEY'));
+        $this->chat = $this->client->geminiFlash()->startChat(history: [
+            ...$this->formatChatHistory()
+        ]);
+    }
+
+    public function sendQuestion(Request $request)
+    {
+        $question = $request->input('question');
+        $response = $this->chat->sendMessage($question);
+
+        return response()->json(['response' => $response->text()]);
+    }
+
+    private function formatChatHistory()
+    {
+        $history = $this->getChatHistory();
+        return array_map(function($message) {
+            return Content::parse(
+                part: $message['parts'][0]['text'],
+                role: $message['role'] === 'model' ? Role::MODEL : Role::USER
+            );
+        }, $history);
+    }
+
+    private function getChatHistory()
+    {
+        return $history = [
+            [
+                "role" => "user",
+                "parts" => [
+                    [
+                        "text" => "Vou te dar várias perguntas e respostas sobre o VoteNow, uma plataforma de votações. As perguntas para treino iniciarão com a flag '[t]'. Por favor, responda apenas a perguntas relacionadas ao VoteNow, uma plataforma de votação online. Evite responder sobre outros tópicos ou fornecer informações que não sejam diretamente relacionadas a esta plataforma. Caso a pergunta não seja sobre o VoteNow, encaminhe de volta com uma mensagem informando que a dúvida está fora do escopo."
+                    ]
+                ]
+            ],
+            [
+                "role" => "user",
+                "parts" => [
+                    [
+                        "text" => "[t] Como posso criar uma sala de votação?"
+                    ]
+                ]
+            ],
+            [
+                "role" => "model",
+                "parts" => [
+                    [
+                        "text" => "Para criar uma sala de votação, vá até o painel de administração e clique em 'Criar Sala'. Escolha um nome para sua sala, adicione a pergunta e as opções de resposta. Você também pode adicionar uma imagem e gerar um código de acesso ou QR Code para compartilhar com os participantes."
+                    ]
+                ]
+            ],
+            [
+                "role" => "user",
+                "parts" => [
+                    [
+                        "text" => "[t] Como personalizo a pergunta na sala de votação?"
+                    ]
+                ]
+            ],
+            [
+                "role" => "model",
+                "parts" => [
+                    [
+                        "text" => "Para personalizar a pergunta, ao criar ou editar sua sala de votação, basta inserir o texto da pergunta no campo específico. Você também pode adicionar uma imagem relacionada à pergunta para tornar a votação mais interativa."
+                    ]
+                ]
+            ],
+            [
+                "role" => "user",
+                "parts" => [
+                    [
+                        "text" => "[t] Posso adicionar uma imagem à pergunta?"
+                    ]
+                ]
+            ],
+            [
+                "role" => "model",
+                "parts" => [
+                    [
+                        "text" => "Sim, você pode adicionar uma imagem à pergunta. Durante a criação ou edição da sala de votação, há uma opção para inserir uma URL de imagem que será exibida junto à pergunta. Isso pode tornar a votação mais visual e atrativa para os participantes."
+                    ]
+                ]
+            ],
+            [
+                "role" => "user",
+                "parts" => [
+                    [
+                        "text" => "[t] Como funciona o código da sala?"
+                    ]
+                ]
+            ],
+            [
+                "role" => "model",
+                "parts" => [
+                    [
+                        "text" => "Cada sala de votação recebe um código único de 6 dígitos. Os participantes podem usar esse código para entrar na sala de votação. Para acessá-la, basta digitar o código no campo de entrada na página inicial ou no link que você compartilhar."
+                    ]
+                ]
+            ],
+            [
+                "role" => "user",
+                "parts" => [
+                    [
+                        "text" => "[t] Como posso compartilhar o QR Code da sala de votação?"
+                    ]
+                ]
+            ],
+            [
+                "role" => "model",
+                "parts" => [
+                    [
+                        "text" => "Durante a criação ou edição da sala, você pode gerar um QR Code único. Esse código pode ser escaneado pelos participantes para entrar diretamente na sua sala de votação. Basta compartilhar o QR Code em eventos, redes sociais ou até imprimir."
+                    ]
+                ]
+            ],
+            [
+                "role" => "user",
+                "parts" => [
+                    [
+                        "text" => "[t] Como as opções de voto são exibidas na sala de votação?"
+                    ]
+                ]
+            ],
+            [
+                "role" => "model",
+                "parts" => [
+                    [
+                        "text" => "Quando os participantes entram na sala de votação, a pergunta e as opções de voto são exibidas de forma clara e interativa. As opções podem ser apresentadas como botões clicáveis, e os participantes devem selecionar uma opção para registrar seu voto."
+                    ]
+                ]
+            ],
+            [
+                "role" => "user",
+                "parts" => [
+                    [
+                        "text" => "[t] Posso editar uma sala depois de criada?"
+                    ]
+                ]
+            ],
+            [
+                "role" => "model",
+                "parts" => [
+                    [
+                        "text" => "Sim, você pode editar uma sala de votação a qualquer momento. Basta ir até a página de gerenciamento da sala, fazer as alterações necessárias (como editar a pergunta, as opções ou o nome da sala) e salvar as mudanças. A sala continuará disponível para os participantes."
+                    ]
+                ]
+            ],
+            [
+                "role" => "user",
+                "parts" => [
+                    [
+                        "text" => "[t] Qual é o limite de participantes em uma sala de votação?"
+                    ]
+                ]
+            ],
+            [
+                "role" => "model",
+                "parts" => [
+                    [
+                        "text" => "Não há limite fixo para o número de participantes em uma sala de votação. O limite depende do plano do aplicativo e dos recursos do servidor, mas geralmente, você pode ter um número bastante grande de participantes em cada sala."
+                    ]
+                ]
+            ],
+            [
+                "role" => "user",
+                "parts" => [
+                    [
+                        "text" => "[t] Como os participantes entram na sala de votação?"
+                    ]
+                ]
+            ],
+            [
+                "role" => "model",
+                "parts" => [
+                    [
+                        "text" => "Os participantes podem entrar na sala de votação de duas formas: digitando o código da sala na página de entrada ou escaneando o QR Code gerado para a sala."
+                    ]
+                ]
+            ],
+            [
+                "role" => "user",
+                "parts" => [
+                    [
+                        "text" => "[t] Qual o nome da aplicação/site/empresa?"
+                    ]
+                ]
+            ],
+            [
+                "role" => "model",
+                "parts" => [
+                    [
+                        "text" => "VoteNow"
+                    ]
+                ]
+            ]
+        ];
+        
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,9 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "inertiajs/inertia-laravel": "^1.0",
+        "google-gemini-php/client": "^1.0",
+        "guzzlehttp/guzzle": "^7.9",
+        "inertiajs/inertia-laravel": "^1.3",
         "laravel/framework": "^11.9",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "525db632943fb1f2514b08f1b8230392",
+    "content-hash": "9a885d360e911cb51a12c051deee2701",
     "packages": [
         {
             "name": "brick/math",
@@ -580,6 +580,69 @@
                 }
             ],
             "time": "2023-10-12T05:21:21+00:00"
+        },
+        {
+            "name": "google-gemini-php/client",
+            "version": "1.0.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/google-gemini-php/client.git",
+                "reference": "11e7413b231dd2ab7ca6169f780d6cc4eeae41a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/google-gemini-php/client/zipball/11e7413b231dd2ab7ca6169f780d6cc4eeae41a1",
+                "reference": "11e7413b231dd2ab7ca6169f780d6cc4eeae41a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1.0",
+                "php-http/discovery": "^1.19.2"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.8.1",
+                "guzzlehttp/psr7": "^2.6.2",
+                "laravel/pint": "^1.18.1",
+                "mockery/mockery": "^1.6.7",
+                "pestphp/pest": "^2.30",
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Gemini.php"
+                ],
+                "psr-4": {
+                    "Gemini\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fatih AYDIN",
+                    "email": "aydinfatih52@gmail.com"
+                }
+            ],
+            "description": "Gemini API is a supercharged PHP API client that allows you to interact with the Gemini API",
+            "keywords": [
+                "Gemini",
+                "client",
+                "gemini-pro",
+                "language",
+                "natural",
+                "nlp",
+                "php",
+                "processing",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/google-gemini-php/client/issues",
+                "source": "https://github.com/google-gemini-php/client/tree/1.0.14"
+            },
+            "time": "2024-11-06T17:51:13+00:00"
         },
         {
             "name": "graham-campbell/result-type",
@@ -2470,6 +2533,85 @@
                 }
             ],
             "time": "2024-11-21T10:39:51+00:00"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0",
+                "zendframework/zend-diactoros": "*"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "*",
+                "psr/http-factory-implementation": "*",
+                "psr/http-message-implementation": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.2|^2.0",
+                "graham-campbell/phpspec-skip-example-extension": "^5.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
+                "sebastian/comparator": "^3.0.5 || ^4.0.8",
+                "symfony/phpunit-bridge": "^6.4.4 || ^7.0.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Http\\Discovery\\Composer\\Plugin",
+                "plugin-optional": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Composer/Plugin.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds and installs PSR-7, PSR-17, PSR-18 and HTTPlug implementations",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr17",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/discovery/issues",
+                "source": "https://github.com/php-http/discovery/tree/1.20.0"
+            },
+            "time": "2024-10-02T11:20:13+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -8032,12 +8174,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\RoomController;
 use App\Http\Controllers\VoteController;
+use App\Http\Controllers\ChatBotController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', [VoteController::class, 'enterRoom']);
@@ -38,5 +39,7 @@ Route::get('/vote/{code}', [VoteController::class, 'showRoom'])->name('votes.roo
 Route::post('/vote/{question}', [VoteController::class, 'castVote'])->name('votes.cast');
 
 Route::get('/results/{code}', [RoomController::class, 'seeResult'])->name('rooms.result');
+
+Route::get('/chatbot', [ChatBotController::class, 'sendQuestion']);
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
# Adicionado o endpoint do chatbot.

## Instalação

Rode o seguinte comando para instalar as novas dependências:

```bash
composer install
```

Adicione essa nova linha no arquivo `.env`:
``` env
GEMINI_API_KEY=SuaChaveGemini
```

---

Na minha máquina estava ocorrendo o seguinte erro:
```
cURL error 60: SSL certificate problem: unable to get local issuer certificate (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash:generateContent
```

Caso isso também ocorra em seu computador, considere adicionar este arquivo na pasta do PHP (qualquer outro lugar também serve. Escolhi na pasta do PHP por ser mais organizado): [cacert.pem](https://curl.se/ca/cacert.pem)

Após isso, coloque a seguinte linha no arquivo `php.ini` (Geralmente esse arquivo fica em `C:\php-[versão do PHP]\php.ini`):

``` ini
# Coloque o local de onde você armazenou o arquivo baixado acima
curl.cainfo="`C:\php-[versão do PHP]\cacert.pem"
```

## Usando o endpoint

Para usar o endpoint do chatbot, basta acessar a rota `/chatbot` pelo método GET, usando o parâmetro `question` para enviar uma pergunta à IA.

Exemplo:
```
http://127.0.0.1:8000/chatbot?question=Como%20usar%20o%20votenow
```
